### PR TITLE
extend tests and make sure closing works as expected

### DIFF
--- a/distributed_heterogeneous/tests/test_heterogeneous.py
+++ b/distributed_heterogeneous/tests/test_heterogeneous.py
@@ -1,11 +1,42 @@
+import asyncio
+import time
+
 import pytest
 from distributed import Scheduler, Worker
-from distributed.utils_test import gen_test, loop, cleanup, loop_in_thread
+from distributed.utils_test import gen_test
+
 from distributed_heterogeneous import HeterogeneousCluster
 
 
 @gen_test()
-async def test_basic(loop):
+async def test_multiple_pools_async():
+    scheduler = {"cls": Scheduler, "options": {"dashboard_address": ":0"}}
+    workers = {
+        "low-memory-pool": {"cls": Worker, "options": {"memory_limit": "1GB"}},
+        "high-memory-pool": {"cls": Worker, "options": {"memory_limit": "3GB"}},
+    }
+    cluster = await HeterogeneousCluster(
+        scheduler=scheduler,
+        worker=workers,
+        asynchronous=True,
+    )
+    assert cluster.asynchronous
+    cluster.scale(2, pool="low-memory-pool")
+    cluster.scale(1, pool="high-memory-pool")
+    await cluster.wait_for_workers(3)
+
+    cluster.scale(0, pool="low-memory-pool")
+    while len(cluster.scheduler_info["workers"]) != 1:
+        await asyncio.sleep(0.1)
+
+    cluster.scale(0, pool="high-memory-pool")
+
+    while cluster.scheduler_info["workers"]:
+        await asyncio.sleep(0.1)
+    await cluster.close()
+
+
+def test_basic_sync():
     scheduler = {"cls": Scheduler, "options": {"dashboard_address": ":0"}}
     workers = {
         "low-memory-pool": {"cls": Worker, "options": {"memory_limit": "1GB"}},
@@ -13,11 +44,12 @@ async def test_basic(loop):
     cluster = HeterogeneousCluster(
         scheduler=scheduler,
         worker=workers,
-        shutdown_on_close=True,
-        asynchronous=True,
-        loop=loop,
     )
     cluster.scale(3, pool="low-memory-pool")
+    cluster.wait_for_workers(3)
     cluster.scale(0, pool="low-memory-pool")
-    cluster.worker_spec
+
+    assert len(cluster.worker_spec) == 0
+    while cluster.scheduler_info["workers"]:
+        time.sleep(0.1)
     cluster.close()


### PR DESCRIPTION
I enable scale to take multiple pools. If no pools are provided, we'll scale up every pool. This allows us to still call `scale(0)` in the base class and enable clean shutdown